### PR TITLE
fix(chaos): updating the setup to setup the pod informer

### DIFF
--- a/cmd/chaos/main.go
+++ b/cmd/chaos/main.go
@@ -50,6 +50,7 @@ func NewApp(l *slog.Logger) (*App, error) {
 func (a *App) Start() error {
 	if err := a.base.Start(
 		web.WithInClusterKubeClient(),
+		web.WithKubernetesPodInformer(),
 		web.WithIndefiniteAsyncTask("pod-chaos", a.podChaos),
 	); err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a small but significant enhancement to the `Start` method in the `App` struct within `cmd/chaos/main.go`. It adds support for initializing a Kubernetes Pod Informer during the application's startup process.

* [`cmd/chaos/main.go`](diffhunk://#diff-198dd1b8e933c081ec763550cdd8307b07212758cb371024b42604e4ddae8cd2R53): Added `web.WithKubernetesPodInformer()` to the `Start` method, enabling the application to monitor Kubernetes Pod events.